### PR TITLE
Add network specification and architecture diagram

### DIFF
--- a/frontend_specification.org
+++ b/frontend_specification.org
@@ -1,14 +1,17 @@
 * Frontend Specification
 
-This file details the frontend implementation.
+This file details the frontend implementation for both terminal and web interfaces.
+For network protocol and data structure specifications, see network_specification.org.
 
-** Functions
+** Terminal Interface
 
-* output_lobby()
+*** Functions
+
+**** output_lobby()
    - Outputs all players in the lobby
    - Outputs all tables with the players in the table
 
-* render_screen()
+**** render_screen()
    - Clears the terminal screen for clean display
    - Shows current lobby status using output_lobby()
    - Shows current player's token if connected
@@ -23,8 +26,52 @@ This file details the frontend implementation.
      3 [table_name]  - Start table (e.g., "3 mytable [token]")
      4               - Exit (e.g., "4 [token]")
 
-   - Gets and returns user input choice
-   - Returns: tuple containing (command, args, token)
+   Returns: tuple containing (command, args, token)
      - command: string containing the numeric command (1-5)
      - args: string containing any additional arguments (table name, player name)
      - token: string containing the player's token (None if not connected)
+
+** Web Interface
+
+*** Components
+
+**** LoginForm
+- Input field for player name
+- Connect button
+- Handles player registration and token storage
+
+**** LobbyView
+- Real-time display of connected players
+- List of available tables with player counts
+- Create table form with:
+  - Table name input
+  - Number of rounds input
+  - Create button
+- Join/Start buttons for each table
+- Logout button
+
+**** TableView
+- Display of current table status
+- List of players in table
+- Start game button (visible to table creator)
+- Leave table button
+
+*** State Management
+- Current player token
+- Connection status
+- Current view (login/lobby/table)
+- Lobby data (players, tables)
+- Current table data
+
+*** WebSocket Events
+- Handle incoming lobby updates
+- Update UI components in real-time
+- Manage table state changes
+- Handle game start/end transitions
+
+*** Styling
+- Responsive design for various screen sizes
+- Clear visual hierarchy
+- Consistent color scheme and typography
+- Interactive elements (buttons, forms) styling
+- Status indicators for connection state

--- a/network_specification.org
+++ b/network_specification.org
@@ -1,0 +1,60 @@
+* Network Specification
+
+This file details the network protocol implementation for the Doppelkopf game.
+
+** WebSocket Protocol
+
+*** Connection Management
+- Server endpoint: ws://localhost:[port]/game
+- Connection establishment process
+- Heartbeat mechanism
+- Reconnection handling
+- Connection state tracking
+
+*** Message Protocol
+**** Common Message Structure
+- Format: JSON
+- Base structure: {type: string, payload: any, timestamp: number}
+- Error handling format: {type: "error", code: number, message: string}
+
+**** Message Types
+***** Player Management
+- player_connect: {name: string} -> {token: string}
+- player_disconnect: {token: string}
+
+***** Table Operations
+- table_create: {name: string, rounds: number, token: string}
+- table_join: {tableName: string, token: string}
+- table_start: {tableName: string, token: string}
+- table_leave: {tableName: string, token: string}
+
+***** Game Updates
+- game_update: {gameState: GameState, players: Player[], currentTurn: string}
+- game_action: {type: string, data: any, token: string}
+
+***** Lobby Updates
+- lobby_update: {players: Player[], tables: Table[]}
+
+*** Data Structures
+
+**** Player
+- name: string
+- uuid: string
+- status: "connected" | "disconnected" | "in_game"
+
+**** Table
+- tablename: string
+- players: Player[]
+- rounds: number
+- status: "waiting" | "in_progress" | "completed"
+
+**** LobbyStatus
+- players: Player[]
+- tables: Table[]
+
+*** Error Handling
+- Connection failures
+- Invalid message format
+- Authentication errors
+- Game state conflicts
+- Rate limiting

--- a/readme.org
+++ b/readme.org
@@ -38,9 +38,32 @@ The project aims to provide an accessible, well-documented platform for playing 
 - State logging and replay system
 - Testing framework
 
+** System Architecture
+#+BEGIN_SRC mermaid
+graph TB
+    subgraph Server
+        CoreLogic[Core Logic] --- ServerAdapter[Server Socket Adapter]
+    end
+    
+    subgraph Client
+        ServerAdapter --- ClientAdapter[Client Socket Adapter]
+        ClientAdapter --- TerminalUI[Terminal UI]
+        ClientAdapter --- BrowserUI[Browser UI]
+    end
+
+    style Server fill:#f9f,stroke:#333,stroke-width:4px
+    style Client fill:#bbf,stroke:#333,stroke-width:4px
+    style CoreLogic fill:#fff,stroke:#333,stroke-width:2px,font-size:18px,color:#000
+    style ServerAdapter fill:#fff,stroke:#333,stroke-width:2px,font-size:18px,color:#000
+    style ClientAdapter fill:#fff,stroke:#333,stroke-width:2px,font-size:18px,color:#000
+    style TerminalUI fill:#fff,stroke:#333,stroke-width:2px,font-size:18px,color:#000
+    style BrowserUI fill:#fff,stroke:#333,stroke-width:2px,font-size:18px,color:#000
+#+END_SRC
+
 * Documentation
 ** Specifications
 - [[frontend_specification.org][Frontend Specification]]: UI implementation details
+- [[network_specification.org][Network Specification]]: WebSocket protocol and data structures
 - [[gameplay_specification.org][Gameplay Specification]]: Game mechanics and rules
 - [[lobby_and_table_creation_specification.org][Lobby and Table Creation]]: Server initialization and table management
 - [[table_creation_specification.org][Table Creation]]: Detailed table setup process


### PR DESCRIPTION
- Create network_specification.org for WebSocket protocol details
- Move network-related content from frontend spec to network spec
- Add system architecture diagram to readme.org